### PR TITLE
cache golang build files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,14 @@
+# syntax = docker/dockerfile:1.2
+
 FROM golang:latest
 WORKDIR /go/src/github.com/kris-nova/nivenly.com
 COPY app app
 COPY main.go main.go
-COPY go.mod go.mod
-COPY go.sum go.sum
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /nivenly
+COPY go.mod go.sum ./
+RUN \
+    --mount=target=go-cache --mount=target=/root/.cache,type=cache \
+    --mount=target=go-mod --mount=target=/go/pkg/mod,type=cache \
+    CGO_ENABLED=0 GOOS=linux go build -installsuffix cgo -o /nivenly
 
 
 FROM alpine:latest


### PR DESCRIPTION
Please try building this first, make sure it works on your system. I don't know if the feature is still experimental on docker.

On my system:

```sh
docker build -t foo .  0.32s user 0.52s system 5% cpu 14.299 total

vs

docker build -t foo .  0.36s user 0.31s system 20% cpu 3.281 total
```

Signed-off-by: Frederick F. Kautz IV <fkautz@alumni.cmu.edu>